### PR TITLE
Change &String to &str, limiting String's/Vec's to u32 indices to avoid overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,8 @@ authors = ["Xun Li <lxfind@gmail.com>"]
 edition = "2018"
 repository = "https://github.com/lxfind/rust-generalized-suffix-tree"
 
+[dependencies]
+mediumvec = "1.0.4"
+
 [dev-dependencies]
 rand = "0.7.0"

--- a/src/disjoint_set.rs
+++ b/src/disjoint_set.rs
@@ -8,13 +8,13 @@ pub struct DisjointSet {
 }
 
 impl DisjointSet {
-    pub fn new(size: usize) -> DisjointSet {
+    pub fn new(size: usize) -> Self {
         let mut ancestors = Vec::with_capacity(size);
         for i in 0..size {
             // MakeSet(i)
             ancestors.push(i);
         }
-        DisjointSet { ancestors }
+        Self { ancestors }
     }
 
     pub fn find_set(&mut self, index: usize) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ impl GeneralizedSuffixTree {
         self.process_suffixes(str_id);
     }
 
-    fn validate_string(&self, s: &String, term: char) {
+    fn validate_string(&self, s: &str, term: char) {
         assert!(term.is_ascii(), "Only accept ASCII terminator");
         assert!(
             !s.contains(term),
@@ -268,7 +268,7 @@ impl GeneralizedSuffixTree {
 
     /// Find the longest common substring between string `s` and the current suffix.
     /// This function allows us compute this without adding `s` to the suffix.
-    pub fn longest_common_substring_with<'a>(&self, s: &'a String) -> &'a str {
+    pub fn longest_common_substring_with<'a>(&self, s: &'a str) -> &'a str {
         let mut longest_start: IndexType = 0;
         let mut longest_len: IndexType = 0;
         let mut cur_start: IndexType = 0;
@@ -540,7 +540,7 @@ impl GeneralizedSuffixTree {
         &mut self.node_storage[node_id as usize]
     }
 
-    fn get_string(&self, str_id: StrID) -> &String {
+    fn get_string(&self, str_id: StrID) -> &str {
         &self.str_storage[str_id as usize]
     }
 


### PR DESCRIPTION
I've changed `&String` arguments to `&str`. This allows users to e.g. check for substrings within the tree without needing to own those substrings. This should be backwards-compatible, because `&String` is automatically coerced to `&str`.

I've also limited all `String`'s/`Vec`'s to `u32` indices. There were no overflow checks before when converting between various index types, but now any attempt to use an index larger than `IndexType::max_value()` should trigger an explicit panic.

I also made a few changes suggested by Clippy.